### PR TITLE
3 Ignore SESI HDAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Config options currently supported:
 - `release_plugin (str)`: The name of the release plugin to use. If unset us `DefaultRelease`.
 - `rez_packages_root (str)`: The main path to where rez packages are released.
 - `rez_package_name (str)`: The name of the rez package used by `NodeManager`.
+- `hda_exclude_path (list(str))`: A list of paths which will be ignored by `NodeManager` when identifying definitions it can work with. Note: this can also be set using the `$NODE_MANAGER_HDA_EXCLUDE_PATH` environment variable.
+- `include_all_hdas (bool)`: Should the NodeManager consider all HDAs, including those excluded because they are part of the SESI installation or are excluded via either of the previous methods.
+
+### Environment Variables
+Some elements of the NodeManager can be configured by setting environment variables.
+
+Currently supported variables are:
+- `$NODE_MANAGER_HDA_EXCLUDE_PATH`: A `os.pathsep` separated list of paths which will be ignored by `NodeManager` when identifying definitions it can work with. Note: this can also be set using the `$NODE_MANAGER_HDA_EXCLUDE_PATH` environment variable.
 
 ### Plugin System
 Node Manager supports a plugin system which can be used to configure the behaviour at different points of the workflow. The current stages where plugins operate are detailed below.

--- a/lib/python/node_manager/manager.py
+++ b/lib/python/node_manager/manager.py
@@ -172,7 +172,10 @@ class NodeManager(object):
             (bool): Is the node a Node Manager node?
         """
         # We can reject nodes straight away if they are not digital assets.
-        if not nodeutils.is_digital_asset(current_node.path()):
+        if not nodeutils.is_digital_asset(
+            current_node.path(),
+            include_hidden=self.config.get("include_all_hdas", False)
+        ):
             return False
 
         definition = nodeutils.definition_from_node(current_node.path())

--- a/lib/python/node_manager/menu.py
+++ b/lib/python/node_manager/menu.py
@@ -7,6 +7,7 @@ import sys
 
 import hdefereval
 
+from node_manager import config
 from node_manager import manager
 from node_manager.utils import nodeutils
 
@@ -23,8 +24,18 @@ def get_node_manager():
 
 
 def display_node_manager(current_node):
-    # We can reject nodes straight away if they are not digital assets.
-    if nodeutils.is_digital_asset(current_node.path()):
+    """Should the Node Manager menu be displayed for the given node.
+
+    Args:
+        current_node(hou.Node): The node to check.
+
+    Returns:
+        bool: Should the Node Manager menu be displayed?
+    """
+    if nodeutils.is_digital_asset(
+        current_node.path(),
+        include_hidden=config.node_manager_config.get("include_all_hdas", False)
+    ):
         return True
     else:
         return False

--- a/lib/python/node_manager/utils/callbackutils.py
+++ b/lib/python/node_manager/utils/callbackutils.py
@@ -6,6 +6,7 @@ import logging
 
 import hou
 
+from node_manager import config
 from node_manager import utils
 from node_manager.utils import nodeutils
 
@@ -44,9 +45,12 @@ def node_changed(current_node):
         logger.debug("UI available, cosmetic callbacks enabled.")
 
     # Is the node a digital asset?
-    if not nodeutils.is_digital_asset(current_node.path()):
+    if not nodeutils.is_digital_asset(
+        current_node.path(),
+        include_hidden=config.node_manager_config.get("include_all_hdas", False)
+    ):
         logger.debug(
-            "Skipping node that isn't digital asset: {node}".format(
+            "Skipping node that isn't a NodeManager digital asset: {node}".format(
                 node=current_node.name(),
             )
         )

--- a/lib/python/node_manager/utils/nodeutils.py
+++ b/lib/python/node_manager/utils/nodeutils.py
@@ -269,7 +269,7 @@ def is_digital_asset(node_path, include_hidden=False):
             exclude_paths_envvar_str = os.getenv("NODE_MANAGER_HDA_EXCLUDE_PATH")
             if exclude_paths_envvar_str:
                 logger.debug("Excluding HDAs from envvar: {path}".format(path=exclude_paths_envvar_str))
-                exclude_paths_envvar = exclude_paths_envvar_str.split(":")
+                exclude_paths_envvar = exclude_paths_envvar_str.split(os.pathsep)
             else:
                 exclude_paths_envvar = []
             full_exclude_paths = exclude_paths + exclude_paths_envvar

--- a/lib/python/node_manager/utils/nodeutils.py
+++ b/lib/python/node_manager/utils/nodeutils.py
@@ -3,8 +3,11 @@
 """Houdini node utility functions."""
 
 import logging
+import os
 
 import hou
+
+from node_manager import config
 
 
 logger = logging.getLogger(__name__)
@@ -242,19 +245,44 @@ def definition_from_node(node_path):
     return None
 
 
-def is_digital_asset(node_path):
+def is_digital_asset(node_path, include_hidden=False):
     """
-    Check if the given node path is a digital asset.
+    Check if the given node path is a digital asset that the NodeManager should handle.
 
     Args:
         node_path(str): The Houdini node path to check.
+        include_hidden(bool): Should hidden HDAs be included in the check?
 
     Returns:
         (bool): Is the node at the given path a digital asset.
     """
-    if definition_from_node(node_path):
-        return True
+    definition = definition_from_node(node_path)
+    if definition:
+        if include_hidden:
+            return True
+        else:
+            library_path = definition.libraryFilePath()
+            logger.debug("Checking definition with library path: {path}".format(path=library_path))
+            exclude_paths = config.node_manager_config.get("hda_exclude_path", [])
+            logger.debug("Excluding HDAs from: {path}".format(path=exclude_paths))
 
+            exclude_paths_envvar_str = os.getenv("NODE_MANAGER_HDA_EXCLUDE_PATH")
+            if exclude_paths_envvar_str:
+                logger.debug("Excluding HDAs from envvar: {path}".format(path=exclude_paths_envvar_str))
+                exclude_paths_envvar = exclude_paths_envvar_str.split(":")
+            else:
+                exclude_paths_envvar = []
+            full_exclude_paths = exclude_paths + exclude_paths_envvar
+
+            sesi_path = os.getenv("HFS")
+            if sesi_path:
+                logger.debug("Excluding HDAs from HFS: {path}".format(path=sesi_path))
+                full_exclude_paths.append(sesi_path)
+            else:
+                logger.warning("HFS environment variable not set.")
+            logger.info("Full exclude paths: {paths}".format(paths=full_exclude_paths))
+
+            return not library_path.startswith(tuple(full_exclude_paths))
     return False
 
 


### PR DESCRIPTION
- Ignore HDAs that reside inside the Houdini installation directory.
- Allow HDAs in other locations to be overriden by using either a config setting (`hda_exclude_path`) or an environment variable (`$NODE_MANAGER_HDA_EXCLUDE_PATH`).
- Allow all HDAs to be considered, including those excluded by the previous point by setting a config option (`include_all_hdas`).