### PR TITLE
5 decrease logging verbosity

### DIFF
--- a/lib/python/node_manager/manager.py
+++ b/lib/python/node_manager/manager.py
@@ -238,7 +238,7 @@ class NodeManager(object):
             node_manager.nodetype.NodeType: The nodetype for the given definition.
         """
         logger.debug(
-            "Looking up Node Manager NodeType for {definition}".format(
+            "Looking up NodeManager NodeType for {definition}".format(
                 definition=definition.nodeTypeName(),
             )
         )

--- a/lib/python/node_manager/manager.py
+++ b/lib/python/node_manager/manager.py
@@ -256,7 +256,11 @@ class NodeManager(object):
             index = utils.node_type_index(current_name, category)
             return repo.node_types.get(index)
 
-        logger.warning("No NodeType found.")
+        logger.debug(
+            "No NodeManager NodeType found for {defintion}".format(
+                definition=definition.nodeTypeName(),
+            )
+        )
         return None
 
     def repo_from_definition(self, definition):


### PR DESCRIPTION
- Switch `No NodeType found.` warning to debug to make it less annoying.
- Add more detail to `No NodeType found.` log message to make it more useful for debugging.
- General tidy up.