### PR TITLE
Don't set node comment inside locked nodes

### DIFF
--- a/lib/python/node_manager/utils/nodeutils.py
+++ b/lib/python/node_manager/utils/nodeutils.py
@@ -17,6 +17,10 @@ def node_comment(current_node, published=True):
         current_node(hou.Node): The node to set the comment on.
         edit(bool): Whether the node is editable or not.
     """
+    if current_node.isInsideLockedHDA():
+        logger.debug("Skipping locked node: {node}".format(node=current_node.name()))
+        return
+
     state = "Published"
     if not published:
         state = "Editable"

--- a/lib/python/node_manager/utils/nodeutils.py
+++ b/lib/python/node_manager/utils/nodeutils.py
@@ -17,6 +17,8 @@ def node_comment(current_node, published=True):
         current_node(hou.Node): The node to set the comment on.
         edit(bool): Whether the node is editable or not.
     """
+    # Lets aim to come up with a better solution to how we handle node comments, or an alternative approach.
+    # https://github.com/j0nc0x/node_manager/issues/10
     if current_node.isInsideLockedHDA():
         logger.debug("Skipping locked node: {node}".format(node=current_node.name()))
         return


### PR DESCRIPTION
- Quick fix to stop an error relating to setting of node comments on nodes that live inside of a locked HDA.
- Longer term ticket here https://github.com/j0nc0x/node_manager/issues/10