### PR TITLE
NodeManager-0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,24 @@ Publish: Write to git and release to versioned directory.
 
 Load: From rez package determined from rez environment.
 Publish: Write to git and release to rez package.
+
+### Edit Directory
+
+In most cases we can assume the read directory is is write protected, but irrespective of this it would be best to avoid editing the released nodes directly.
+
+Instead we should look to allow the node definition file to be copied to a separate edit directory where it lives during the edit process. Ideally the edit directory should be on a network location and available on any render farm machines if applicable.
+
+We should split the edit directory by username to allow people to edit their node changes separately without treading on each others edits.
+
+The node manager will need to provide a mechanism for placing a copy of the node for editing purposes in the user's edit directory. It should also provide a way of discarding and nodes currently in an edit state.
+- Provide UI menu options to allow node to be copied for editing, allowing the major or minor version to be incremented at the same point.
+  - Edit - copy to edit directory, no change to version.
+  - Edit Major - copy to edit directory, increment major version.
+  - Edit Minor - copy to edit directory, increment minor version.
+  - Edit Custom - provide the same functionality as in the "Digital Assets - Save As" UI element.
+
+
+Ideally it would be desirable to feedback to the user whether nodes are in an editable state in the UI. Possibly this could be done with:
+- Node message.
+- Node colour.
+

--- a/README.md
+++ b/README.md
@@ -64,21 +64,25 @@ Build plugin system for handling default HDA storage options split into plugin c
 #### (Default) Folder on disk
 
 Load: Basic load from folder on disk.
+
 Publish: Basic write to folder on disk.
 
 #### Git
 
 Load: Directly from git with support to load a specific commit.
+
 Publish: Write directly to git applying version tag.
 
 #### Git Versioned Directory
 
 Load: From versioned directory with support for loading specific directory.
+
 Publish: Write to git and release to versioned directory.
 
 #### Rez Package
 
 Load: From rez package determined from rez environment.
+
 Publish: Write to git and release to rez package.
 
 ### Edit Directory

--- a/README.md
+++ b/README.md
@@ -57,3 +57,19 @@ Cons:
 - Difficult / not possible to capture release comments.
 - No choices on when to publish, always include everything (maybe a pro).
 - Lock on farm by pulling a certain commit / tag.
+
+### Plugin system
+Build plugin system for handling default HDA storage options split into plugin category for load and publish. Allow plugins to be selected using config file.
+
+Load:
+
+- (Default) Basic load from folder on disk.
+- Load directly from git with support to load specific commit.
+- Load from versioned directory with support for loading specific directory.
+- Load from rez package determined from rez environment.
+
+Publish:
+- (Default) Basic write to folder on disk.
+- Write directly to git applying version tag.
+- Write to git and release to versioned directory.
+- Write to git and release to rez package.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Node Manager
-Manage and track Houdini HDAs and Nuke Gizmos/Snippets
+Manage and track Houdini HDAs and Nuke Gizmos/Snippets.
 
 ### General Design Points
 ## Design Points

--- a/README.md
+++ b/README.md
@@ -61,15 +61,22 @@ Cons:
 ### Plugin system
 Build plugin system for handling default HDA storage options split into plugin category for load and publish. Allow plugins to be selected using config file.
 
-Load:
+#### (Default) Folder on disk
 
-- (Default) Basic load from folder on disk.
-- Load directly from git with support to load specific commit.
-- Load from versioned directory with support for loading specific directory.
-- Load from rez package determined from rez environment.
+Load: Basic load from folder on disk.
+Publish: Basic write to folder on disk.
 
-Publish:
-- (Default) Basic write to folder on disk.
-- Write directly to git applying version tag.
-- Write to git and release to versioned directory.
-- Write to git and release to rez package.
+#### Git
+
+Load: Directly from git with support to load a specific commit.
+Publish: Write directly to git applying version tag.
+
+#### Git Versioned Directory
+
+Load: From versioned directory with support for loading specific directory.
+Publish: Write to git and release to versioned directory.
+
+#### Rez Package
+
+Load: From rez package determined from rez environment.
+Publish: Write to git and release to rez package.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Node Manager
-Manage and track Houdini HDAs and Nuke Gizmos/Snippets.
+Manage and track Houdini HDAs (and in the future, Nuke Gizmos/Snippets).
 
 ### General Design Points
 ## Design Points

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ Manage and track Houdini HDAs and Nuke Gizmos/Snippets
 
 #### Versioned Directories
 Pros:
+
 - HDAs stored on disk as binary for fast loading.
 - More storage due to duplication of data between versions.
 - Easily implement solutions to hide / show HDAs being edited and also to chose to see other users WIP.
 
 Cons:
+
 - Less like working with a directory of HDAs on disk.
 - HDAs require (auto) copying to a working directory to edit.
 - Updates into a live Houdini session cumbersome.
@@ -23,29 +25,35 @@ Cons:
 
 #### Local HDA dir / repo clone:
 Pros:
+
 - HDAs pulled and built when required, small disk space wastage.
 - Updates into a live Houdini session relatively easy, pull / build the latest refresh HDAs.
 
 Cons:
+
 HDAs pulled and built when required, this will add to load times
   - How to handle merge if heads have diverged on pull.
 
 
 #### Central HDA dir / local repo clone:
 Pros:
+
 - Much more like working with a simple HDA folder on disk.
 - You will see all users HDAs as they are being developed.
 
 Cons:
+
 - Technically you will be able to publish anyone's updates (maybe a pro?).
 - Difficult to lock changes for use on the farm. Maybe require publish and build from repo on farm.
 
 #### Central HDA dir / auto publish:
 Pros:
+
 - Basically a shared folder on disk.
 - Publishes happen automatically on certain events - save, submission to farm etc.
 
 Cons:
+
 - Difficult / not possible to capture release comments.
 - No choices on when to publish, always include everything (maybe a pro).
 - Lock on farm by pulling a certain commit / tag.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,20 @@
+# Node Manager Release Notes
+
+## 0.2.0 (29/01/24)
+### Features
+#### Ignore SESI HDAs (https://github.com/j0nc0x/node_manager/issues/3)
+- Ignore HDAs that reside inside the Houdini installation directory.
+- Allow HDAs in other locations to be overriden by using either a config setting (`hda_exclude_path`) or an environment variable (`$NODE_MANAGER_HDA_EXCLUDE_PATH`).
+- Allow all HDAs to be considered, including those excluded by the previous point by setting a config option (include_all_hdas).
+### Bugfix
+#### Decrease logging verbosity - No NodeType found (https://github.com/j0nc0x/node_manager/issues/5)
+- Switch `No NodeType found`. warning to debug to make it less annoying.
+- Add more detail to `No NodeType found`. log message to make it more useful for debugging.
+- General tidy up.
+#### Discard Definition: Internal changes not reverted (https://github.com/j0nc0x/node_manager/issues/7)
+- Make sure we match the current node to it's definition during the "Discard Definition" process in order that we also discard any unsaved changes.
+#### Node Comment errors for locked HDAs (https://github.com/j0nc0x/node_manager/issues/9)
+- Quick fix to stop an error relating to setting of node comments on nodes that live inside of a locked HDA.
+
+## 0.1.0 (23/11/23)
+- First release of NodeManager.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,7 +6,7 @@
 - Ignore HDAs that reside inside the Houdini installation directory.
 - Allow HDAs in other locations to be overriden by using either a config setting (`hda_exclude_path`) or an environment variable (`$NODE_MANAGER_HDA_EXCLUDE_PATH`).
 - Allow all HDAs to be considered, including those excluded by the previous point by setting a config option (include_all_hdas).
-### Bugfix
+### Bugfixes
 #### Decrease logging verbosity - No NodeType found (https://github.com/j0nc0x/node_manager/issues/5)
 - Switch `No NodeType found`. warning to debug to make it less annoying.
 - Add more detail to `No NodeType found`. log message to make it more useful for debugging.

--- a/lib/python/node_manager/plugins/gitload.py
+++ b/lib/python/node_manager/plugins/gitload.py
@@ -26,7 +26,7 @@ class NodeManagerPlugin(load.NodeManagerPlugin):
         self.repo.context["git_repo_clone"] = self.git_repo_clone_dir()
         self.repo.context["repo_load_path"] = os.path.join(
             self.manager.context.get("manager_temp_dir"),
-            self.repo.context.get("name"),
+            self.repo.context.get("repo_name"),
         )
         logger.debug(
             "Initialise GitLoad: {repo_path}".format(
@@ -41,7 +41,7 @@ class NodeManagerPlugin(load.NodeManagerPlugin):
             str: The path to the HDA repo on disk.
         """
         return os.path.join(
-            self.manager.context.get("manager_base_dir"), self.repo.context.get("name")
+            self.manager.context.get("manager_base_dir"), self.repo.context.get("repo_name")
         )
 
     def git_repo_clone_dir(self):
@@ -51,7 +51,7 @@ class NodeManagerPlugin(load.NodeManagerPlugin):
             str: The path to the HDA repo on disk.
         """
         return os.path.join(
-            self.repo.context.get("git_repo_root"), self.repo.context.get("name")
+            self.repo.context.get("git_repo_root"), self.repo.context.get("repo_name")
         )
 
     def clone_repo(self):

--- a/lib/python/node_manager/plugins/gitrelease.py
+++ b/lib/python/node_manager/plugins/gitrelease.py
@@ -50,7 +50,7 @@ class NodeManagerPlugin(release.NodeManagerPlugin):
             (str): The package name.
         """
         if self.repo:
-            return self.repo.context.get("name")
+            return self.repo.context.get("repo_name")
         return None
 
     def release_dir(self):

--- a/lib/python/node_manager/plugins/release.py
+++ b/lib/python/node_manager/plugins/release.py
@@ -70,7 +70,7 @@ class NodeManagerPlugin(object):
         logger.debug("Release comment: {comment}".format(comment=release_comment))
 
         logger.debug(
-            "Using release repo: {repo}".format(repo=self.repo.context.get("name"))
+            "Using release repo: {repo}".format(repo=self.repo.context.get("repo_name"))
         )
         logger.debug(
             "Repo path: {path}".format(path=self.repo.context.get("repo_path"))
@@ -90,7 +90,7 @@ class NodeManagerPlugin(object):
             if not backup_directory:
                 raise RuntimeError(
                     "No backup directory found for {repo}".format(
-                        repo=self.repo.context.get("name")
+                        repo=self.repo.context.get("repo_name")
                     )
                 )
 

--- a/lib/python/node_manager/plugins/rezrelease.py
+++ b/lib/python/node_manager/plugins/rezrelease.py
@@ -57,7 +57,7 @@ class NodeManagerPlugin(release.NodeManagerPlugin):
             (str): The package name.
         """
         if self.repo:
-            name = self.repo.context.get("name")
+            name = self.repo.context.get("repo_name")
             return name.split(".")[0]
         return None
 
@@ -342,7 +342,6 @@ class NodeManagerPlugin(release.NodeManagerPlugin):
         remote.push(refspec=(":{branch}".format(branch=branch)))
 
         # clean up release dir
-        # shutil.rmtree(self._release_dir)
         logger.debug(
             "(Would clean) up release directory {path}".format(path=self._release_dir)
         )
@@ -358,7 +357,7 @@ class NodeManagerPlugin(release.NodeManagerPlugin):
         Returns:
             str: The path to the HDA repo on disk."""
         return os.path.join(
-            self.manager.context.get("manager_base_dir"), self.repo.context.get("name")
+            self.manager.context.get("manager_base_dir"), self.repo.context.get("repo_name")
         )
 
     def git_repo_clone_dir(self):
@@ -367,7 +366,7 @@ class NodeManagerPlugin(release.NodeManagerPlugin):
         Returns:
             str: The path to the HDA repo on disk."""
         return os.path.join(
-            self.repo.context.get("git_repo_root"), self.repo.context.get("name")
+            self.repo.context.get("git_repo_root"), self.repo.context.get("repo_name")
         )
 
     def clone_repo(self):

--- a/package.py
+++ b/package.py
@@ -19,5 +19,12 @@ build_command = "{root}/bin/build {install}"
 
 def commands():
     env.PYTHONPATH.append("{root}/lib/python")
+
+    # Note: '&' is used by Houdini to include the default locations for thse paths.
+    # If this is handled elsewhere, either by a "houdini_config" rez package or the
+    # Houdini rez package itself, then the '&' can be removed. See commented out lines
+    # below which can be replaced.
+    #env.HOUDINI_MENU_PATH.append("{root}/dcc/houdini/menu")
+    #env.HOUDINI_PATH.append("{root}/dcc/houdini")
     env.HOUDINI_MENU_PATH.set("{root}/dcc/houdini/menu:&")
     env.HOUDINI_PATH.set("{root}/dcc/houdini:&")

--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = "node_manager"
 
-version = "0.1.0"
+version = "0.2.0"
 
 description = "Houdini Node Manager"
 


### PR DESCRIPTION
### Features
#### Ignore SESI HDAs (https://github.com/j0nc0x/node_manager/issues/3)
- Ignore HDAs that reside inside the Houdini installation directory.
- Allow HDAs in other locations to be overriden by using either a config setting (`hda_exclude_path`) or an environment variable (`$NODE_MANAGER_HDA_EXCLUDE_PATH`).
- Allow all HDAs to be considered, including those excluded by the previous point by setting a config option (include_all_hdas).
### Bugfixes
#### Decrease logging verbosity - No NodeType found (https://github.com/j0nc0x/node_manager/issues/5)
- Switch `No NodeType found`. warning to debug to make it less annoying.
- Add more detail to `No NodeType found`. log message to make it more useful for debugging.
- General tidy up.
#### Discard Definition: Internal changes not reverted (https://github.com/j0nc0x/node_manager/issues/7)
- Make sure we match the current node to it's definition during the "Discard Definition" process in order that we also discard any unsaved changes.
#### Node Comment errors for locked HDAs (https://github.com/j0nc0x/node_manager/issues/9)
- Quick fix to stop an error relating to setting of node comments on nodes that live inside of a locked HDA.